### PR TITLE
Bump axios to 1.12.0

### DIFF
--- a/Server/server/package.json
+++ b/Server/server/package.json
@@ -4,7 +4,7 @@
   "main": "app.js",
   "type": "module",
   "dependencies": {
-    "axios": "^1.8.2",
+    "axios": "^1.12.0",
     "body-parser": "^1.20.1",
     "express": "^4.21.2"
   }


### PR DESCRIPTION
This is to address a security vulnerability that is fixed in v1.12.0. 
Release note from axios: https://github.com/axios/axios/releases/tag/v0.30.2?fbclid=IwY2xjawNQrvxleHRuA2FlbQIxMQABHoejBTQLpN6H_AQoba40h1n58iJtMXg9SOC9fQyvGJxXmPDxLGF_Tza7C7NN_aem_QrQgYu63LKop8qtY09gqXA